### PR TITLE
Remove FMLCorePluginContainsFMLMod marker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,6 @@ processResources {
 jar {
 	manifest {
 		attributes 'FMLCorePlugin': 'me.modmuss50.loadingtips.core.LoadingPlugin'
-		attributes 'FMLCorePluginContainsFMLMod': 'true'
 	}
 }
 


### PR DESCRIPTION
```
[FML]: Found FMLCorePluginContainsFMLMod marker in LoadingTips-1.12.2-1.1.0.jar. This is not recommended, @Mods should be in a separate jar from the coremod.
```

But there is no `@Mod` this mod.